### PR TITLE
Fix config path resolution

### DIFF
--- a/scr/coreclasses/config_loader.py
+++ b/scr/coreclasses/config_loader.py
@@ -1,17 +1,20 @@
 # coreclasses/config_loader.py
 
 import yaml
-import os
+from pathlib import Path
 
 class ConfigLoader:
 
-    def __init__(self, main_config_path, base_path="configs/"):
-        self.base_path = base_path
+    # Absolute path to the configs directory inside the scr package
+    DEFAULT_BASE_PATH = Path(__file__).resolve().parent.parent / "configs"
+
+    def __init__(self, main_config_path, base_path=DEFAULT_BASE_PATH):
+        self.base_path = Path(base_path)
         self.main_config_path = main_config_path
 
-        self.main_cfg = self._load_yaml(os.path.join(base_path, "main", main_config_path))
-        self.dedup_cfg = self._load_yaml(os.path.join(base_path, "dedup", "dedup_presets.yaml"))
-        self.model_cfg = self._load_yaml(os.path.join(base_path, "model", "model_paths.yaml"))
+        self.main_cfg = self._load_yaml(self.base_path / "main" / main_config_path)
+        self.dedup_cfg = self._load_yaml(self.base_path / "dedup" / "dedup_presets.yaml")
+        self.model_cfg = self._load_yaml(self.base_path / "model" / "model_paths.yaml")
 
         self.config = self._merge_configs()
 

--- a/scr/utils/pipeline_builder.py
+++ b/scr/utils/pipeline_builder.py
@@ -1,13 +1,17 @@
 # scr/utils/pipeline_builder.py
 
 import os
+from pathlib import Path
 from coreclasses.config_loader import ConfigLoader
 from coreclasses.managers.modelmanager import ModelManager
 from coreclasses.detectors.facedetector import FaceDetector
 from coreclasses.detectors.pose_emotion import PoseAndEmotionAnalyzer
 from coreclasses.detectors.objectdetector import ObjectDetector
 
-def build_pipeline(config_filename="config_default.yaml", configs_root="configs/"):
+# Absolute path to the configs directory inside the scr package
+DEFAULT_CONFIGS_ROOT = Path(__file__).resolve().parent.parent / "configs"
+
+def build_pipeline(config_filename="config_default.yaml", configs_root=DEFAULT_CONFIGS_ROOT):
     # Load config
     cfg_loader = ConfigLoader(config_filename, base_path=configs_root)
     cfg = cfg_loader.get()


### PR DESCRIPTION
## Summary
- compute config paths relative to library files
- use new default config root in pipeline builder

## Testing
- `python3 -m py_compile scr/utils/pipeline_builder.py scr/coreclasses/config_loader.py scr/cli_run.py`

------
https://chatgpt.com/codex/tasks/task_e_6852c5ce29848321908f796652ad8251