### PR TITLE
Fix project root detection

### DIFF
--- a/scr/coreclasses/managers/modelmanager.py
+++ b/scr/coreclasses/managers/modelmanager.py
@@ -62,10 +62,9 @@ class ModelManager:
         print(f"\r⏬ Downloading: {percent}%", end='')
 
     def _find_project_root(self):
-        """
-        Detects project root automatically based on file location.
-        """
+        """Return the repository root by ascending three directories from this file."""
         this_file = os.path.abspath(__file__)
-        core_dir = os.path.dirname(this_file)
-        project_root = os.path.abspath(os.path.join(core_dir, ".."))
+        project_root = os.path.abspath(
+            os.path.join(os.path.dirname(this_file), "..", "..", "..")
+        )
         return project_root


### PR DESCRIPTION
## Summary
- ensure `ModelManager` looks three directories above this file for the repo root
- `models/` folder will be created under that root as before

## Testing
- `pytest -q`
- `python -m compileall -q scr`


------
https://chatgpt.com/codex/tasks/task_e_6852c5d750a883219d31600b8926af88